### PR TITLE
Handle forward slash in namespace

### DIFF
--- a/src/package-url.js
+++ b/src/package-url.js
@@ -68,7 +68,11 @@ class PackageURL {
     }
 
     if (this.namespace) {
-      purl.push(encodeURIComponent(this.namespace).replace('%3A', ':'));
+      purl.push(
+        encodeURIComponent(this.namespace)
+          .replace('%3A', ':')
+          .replace('%2F', '/')
+        );
       purl.push('/');
     }
 

--- a/test/data/test-suite-data.json
+++ b/test/data/test-suite-data.json
@@ -48,6 +48,18 @@
     "is_invalid": false
   },
   {
+    "description": "valid go purl with namespace that has a forward slash",
+    "purl": "pkg:golang/github.com/etcd-io/etcd@v2.4.0",
+    "canonical_purl": "pkg:golang/github.com/etcd-io/etcd@v2.4.0",
+    "type": "golang",
+    "namespace": "github.com/etcd-io",
+    "name": "etcd",
+    "version": "v2.4.0",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
     "description": "bitbucket namespace and name should be lowercased",
     "purl": "pkg:bitbucket/birKenfeld/pyGments-main@244fd47e07d1014f0aed9c",
     "canonical_purl": "pkg:bitbucket/birkenfeld/pygments-main@244fd47e07d1014f0aed9c",


### PR DESCRIPTION
Ahoy!

While working on some purls specific to `golang`, we noticed that when a namespace has a `/` in it, this is encoded to `%2F`, which we believe to be wrong, based on looking at the `purl-spec`. 

<img width="862" alt="Screen Shot 2021-05-05 at 8 30 37 PM" src="https://user-images.githubusercontent.com/5544326/117241973-c1c31800-ade0-11eb-9921-9ed02a38c33f.png">

This PR ensures that any `%2F` is reconverted back to `/`. 

I added a test for this as well, and I think it's all good to go! Let me know if you need me to change anything, etc... or if this isn't the intent of the `namespace`. 