### PR TITLE
feat: validate versions to ensure they dont begin with special characters

### DIFF
--- a/src/package-url.js
+++ b/src/package-url.js
@@ -174,6 +174,14 @@ class PackageURL {
     if (path.includes('@')) {
       let index = path.indexOf('@');
       version = decodeURIComponent(path.substring(index + 1));
+
+      // Check that version doesnt contain special characters by checking if first char can be encoded
+      let tempEncoded = encodeURIComponent(version[0]);
+      let tempDecoded = decodeURIComponent(version[0]);
+
+      if (tempDecoded !== tempEncoded) {
+        throw new Error('Invalid purl: version should not include special characters');
+      }
       remainder = path.substring(0, index);
     } else {
       remainder = path;

--- a/test/data/test-suite-data.json
+++ b/test/data/test-suite-data.json
@@ -370,5 +370,17 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "invalid maven purl",
+    "purl": "pkg:maven/org.apache.commons/io@@1.4.0",
+    "canonical_purl": "pkg:maven/org.apache.commons/io@@1.4.0",
+    "type": null,
+    "namespace": null,
+    "name": "io",
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": true
   }
 ]


### PR DESCRIPTION
Link to issue: https://github.com/package-url/packageurl-js/issues/48

The spec states: "A version must be a percent-encoded string" as such it shouldnt be possible to to pass in versions that can be url-encoded such as: `pkg:npm/foo@!` `pkg:npm/foo@;` `pkg:npm/foo@{`

Ths PR checks if a version begins with a url-encodable character and if so, throws an error

