### PR TITLE
fix: verify entire version string is properly encoded

### DIFF
--- a/src/package-url.js
+++ b/src/package-url.js
@@ -173,15 +173,18 @@ class PackageURL {
     let version = null;
     if (path.includes('@')) {
       let index = path.indexOf('@');
-      version = decodeURIComponent(path.substring(index + 1));
+      let rawVersion= path.substring(index + 1);
+      version = decodeURIComponent(rawVersion);
 
-      // Check that version doesnt contain special characters by checking if first char can be encoded
-      let tempEncoded = encodeURIComponent(version[0]);
-      let tempDecoded = decodeURIComponent(version[0]);
+      // Convert percent-encoded colons (:) back, to stay in line with the `toString`
+      // implementation of this library.
+      // https://github.com/package-url/packageurl-js/blob/58026c86978c6e356e5e07f29ecfdccbf8829918/src/package-url.js#L98C10-L98C10
+      let versionEncoded = encodeURIComponent(version).replace(/%3A/g, ':');
 
-      if (tempDecoded !== tempEncoded) {
-        throw new Error('Invalid purl: version should not include special characters');
+      if (rawVersion !== versionEncoded) {
+        throw new Error('Invalid purl: version must be percent-encoded');
       }
+
       remainder = path.substring(0, index);
     } else {
       remainder = path;

--- a/test/data/test-suite-data.json
+++ b/test/data/test-suite-data.json
@@ -372,13 +372,13 @@
     "is_invalid": false
   },
   {
-    "description": "invalid maven purl",
-    "purl": "pkg:maven/org.apache.commons/io@@1.4.0",
-    "canonical_purl": "pkg:maven/org.apache.commons/io@@1.4.0",
+    "description": "improperly encoded version string",
+    "purl": "pkg:maven/org.apache.commons/io@1.4.0-$@",
+    "canonical_purl": "pkg:maven/org.apache.commons/io@1.4.0-$@",
     "type": null,
     "namespace": null,
     "name": "io",
-    "version": null,
+    "version": "1.4.0-$@",
     "qualifiers": null,
     "subpath": null,
     "is_invalid": true


### PR DESCRIPTION
The previous version validation in `PackageURL.fromString` was only targetting the first character of the version string. This fix is changing the validation logic to ensure the entire version string is percent-encoded, [as required by the PackageURL specification](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst):

> A version must be a percent-encoded string

Contrary to above specification, it still carries on the logic of keeping colons (`:`) in their decoded format, to keep parity with the serialization logic of `PackageURL.toString()`.

Relates to https://github.com/package-url/packageurl-js/issues/48.