### PR TITLE
Update PackageURL.fromString() to handle colon in the package name

### DIFF
--- a/src/package-url.js
+++ b/src/package-url.js
@@ -138,7 +138,8 @@ class PackageURL {
       throw new Error('A purl string argument is required.');
     }
 
-    let [scheme, remainder] = purl.split(':', 2);
+    let scheme = purl.slice(0, purl.indexOf(':'))
+    let remainder = purl.slice(purl.indexOf(':') + 1)
     if (scheme !== 'pkg') {
       throw new Error('purl is missing the required "pkg" scheme component.');
     }

--- a/test/data/test-suite-data.json
+++ b/test/data/test-suite-data.json
@@ -406,5 +406,17 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": true
+  },
+  {
+    "description": "colon present in name is a valid PURL",
+    "purl": "pkg:maven/:spring-context@5.2.8-RELEASE",
+    "canonical_purl": "pkg:maven/:spring-context@5.2.8-RELEASE",
+    "type": "maven",
+    "namespace": null,
+    "name": ":spring-context",
+    "version": "5.2.8-RELEASE",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
   }
 ]


### PR DESCRIPTION
Fix for the issue https://github.com/package-url/packageurl-js/issues/45.

When multiple colons are present in PURL, the split method considers only the first 2 elements of the spitted array. Fixed this by using the splice method to split the `scheme` and `remainder` correctly.