### PR TITLE
Fix issues #58 & #63

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "packageurl-js",
-  "version": "1.0.1",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "packageurl-js",
-      "version": "1.0.1",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "mocha": "^10.2.0"

--- a/src/package-url.js
+++ b/src/package-url.js
@@ -138,7 +138,8 @@ class PackageURL {
       throw new Error('A purl string argument is required.');
     }
 
-    let [scheme, remainder] = purl.split(':', 2);
+    let scheme = purl.slice(0, purl.indexOf(':'))
+    let remainder = purl.slice(purl.indexOf(':') + 1)
     if (scheme !== 'pkg') {
       throw new Error('purl is missing the required "pkg" scheme component.');
     }

--- a/src/package-url.js
+++ b/src/package-url.js
@@ -149,7 +149,7 @@ class PackageURL {
 
     let type
     [type, remainder] = remainder.split('/', 2);
-    if (!type || !remainder) {
+    if (!type) {
       throw new Error('purl is missing the required "type" component.');
     }
     type = decodeURIComponent(type)
@@ -207,7 +207,7 @@ class PackageURL {
       let nameIndex = remaining.length - 1;
       let namespaceComponents = remaining.slice(0, nameIndex);
       name = decodeURIComponent(remaining[nameIndex]);
-      namespace = decodeURIComponent(namespaceComponents.join('/'));
+      namespace = decodeURIComponent(namespaceComponents.filter(item => item.trim()).join('/'));
     } else if (remaining.length === 1) {
       name = decodeURIComponent(remaining[0]);
     }

--- a/src/package-url.js
+++ b/src/package-url.js
@@ -154,7 +154,8 @@ class PackageURL {
     }
     type = decodeURIComponent(type)
 
-    let url = new URL(purl);
+    // strip /, // and /// as possible in pkg:/ or pkg:// or pkg:///
+    let url = new URL(purl.trim().replace(/^pkg:\/+/g, 'pkg:'));
 
     let qualifiers = null;
     url.searchParams.forEach((value, key) => {
@@ -175,9 +176,7 @@ class PackageURL {
       throw new Error('Invalid purl: cannot contain a "user:pass@host:port"');
     }
 
-    // this strip '/, // and /// as possible in :// or :///
-    // from https://gist.github.com/refo/47632c8a547f2d9b6517#file-remove-leading-slash
-    let path = url.pathname.trim().replace(/^\/+/g, '');
+    let path = url.pathname.trim();
 
     // version is optional - check for existence
     let version = null;

--- a/test/data/test-suite-data.json
+++ b/test/data/test-suite-data.json
@@ -430,5 +430,17 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "In namespace, leading and trailing slashes '/' are not significant and should be stripped in the canonical form",
+    "purl": "pkg:golang//github.com/ll/xlog@2.0",
+    "canonical_purl": "pkg:golang/github.com/ll/xlog@2.0",
+    "type": "golang",
+    "namespace": "github.com/ll",
+    "name": "xlog",
+    "version": "2.0",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
   }
 ]

--- a/test/data/test-suite-data.json
+++ b/test/data/test-suite-data.json
@@ -406,5 +406,17 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": true
+  },
+  {
+    "description": "colon present in name is a valid PURL",
+    "purl": "pkg:maven/:spring-context@5.2.8-RELEASE",
+    "canonical_purl": "pkg:maven/:spring-context@5.2.8-RELEASE",
+    "type": "maven",
+    "namespace": null,
+    "name": ":spring-context",
+    "version": "5.2.8-RELEASE",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
   }
 ]


### PR DESCRIPTION
+ Fix issue https://github.com/package-url/packageurl-js/issues/58 - Incorrect parsing of PURLs beginning with `pkg://`
+ Fix issue https://github.com/package-url/packageurl-js/issues/63 - Incorrect parsing of PURL with leading '/' in namespace


Fix Description
+ strip /, // and /// as possible in pkg:/ or pkg:// or pkg:/// before passing into URL constructor
+ filter for non-empty items in `namespaceComponents`