### PR TITLE
Splitting purl remainder from right on '@' to extract version

### DIFF
--- a/src/package-url.js
+++ b/src/package-url.js
@@ -182,7 +182,7 @@ class PackageURL {
     // version is optional - check for existence
     let version = null;
     if (path.includes('@')) {
-      let index = path.indexOf('@');
+      let index = path.lastIndexOf('@');
       let rawVersion= path.substring(index + 1);
       version = decodeURIComponent(rawVersion);
 

--- a/test/package-url.spec.js
+++ b/test/package-url.spec.js
@@ -77,6 +77,17 @@ describe('PackageURL', function () {
       })
     });
 
+    it('npm PURL with namespace starting with @', function () {
+      const purlString = 'pkg:npm/@aws-crypto/crc32@3.0.0'
+
+      const purl = PackageURL.fromString(purlString)
+
+      assert.strictEqual(purl.type, 'npm')
+      assert.strictEqual(purl.namespace, '@aws-crypto')
+      assert.strictEqual(purl.name, 'crc32')
+      assert.strictEqual(purl.version, '3.0.0')
+    });
+
     it('namespace with multiple segments', function () {
       var purl = PackageURL.fromString('pkg:ty%2Fpe/namespace1/namespace2/na%2Fme')
       assert.strictEqual('ty/pe', purl.type)


### PR DESCRIPTION
NPM purls contain namespaces starting with @ 
pkg:npm/@aws-crypto/crc32@3.0.0