### PR TITLE
Adding missing attribute for golang purl validation

### DIFF
--- a/src/purl-type.js
+++ b/src/purl-type.js
@@ -212,7 +212,7 @@ module.exports = {
                     )
                 },
                 // https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#golang
-                golang(purl) {
+                golang(purl, throws) {
                     // Still being lenient here since the standard changes aren't official.
                     // Pending spec change: https://github.com/package-url/purl-spec/pull/196
                     const { version } = purl


### PR DESCRIPTION
Adding `throws` attribute for golang purl validation.
Please check out the related issue https://github.com/package-url/packageurl-js/issues/85 for more information.