### PR TITLE
fix: add missing throws parameter to golang validator [closes #87]

### DIFF
--- a/src/purl-type.js
+++ b/src/purl-type.js
@@ -212,7 +212,7 @@ module.exports = {
                     )
                 },
                 // https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#golang
-                golang(purl) {
+                golang(purl, throws) {
                     // Still being lenient here since the standard changes aren't official.
                     // Pending spec change: https://github.com/package-url/purl-spec/pull/196
                     const { version } = purl

--- a/test/package-url.spec.js
+++ b/test/package-url.spec.js
@@ -545,4 +545,52 @@ describe('PackageURL', function () {
             )
         })
     })
+
+    describe('golang', function () {
+        it('should throw an error for invalid semver version starting with v', function () {
+            assert.throws(
+                () =>
+                    new PackageURL(
+                        'golang',
+                        'github.com',
+                        'example/pkg',
+                        'v1.0.invalid'
+                    ),
+                /golang "version" component starting with a "v" must be followed by a valid semver version/
+            )
+        })
+
+        it('should allow valid semver version starting with v', function () {
+            assert.doesNotThrow(() => {
+                new PackageURL(
+                    'golang',
+                    'github.com',
+                    'example/pkg',
+                    'v1.0.0'
+                )
+            })
+        })
+
+        it('should allow pseudo-version numbers', function () {
+            assert.doesNotThrow(() => {
+                new PackageURL(
+                    'golang',
+                    'github.com/cncf/xds',
+                    'go',
+                    'v0.0.0-20210922020428-25de7278fc84'
+                )
+            })
+        })
+
+        it('should allow versions without v prefix', function () {
+            assert.doesNotThrow(() => {
+                new PackageURL(
+                    'golang',
+                    'github.com',
+                    'example/pkg',
+                    'abc123'
+                )
+            })
+        })
+    })
 })


### PR DESCRIPTION
Parsing certain Go package URLs crashes instead of validating them. The `golang` validator refers to a variable named `throws` that was never declared in its signature, so as soon as that branch is reached Node raises `ReferenceError: throws is not defined` — a hard crash from inside a library whose whole job is to parse untrusted strings safely.

Adding the missing `throws` parameter, which every other type validator already takes, restores the intended behavior: an invalid version is reported the normal way instead of taking the caller down with it.

Closes #87.

<details>
<summary><b>What the tests pin</b> — the crash case, plus the three shapes that must keep parsing</summary>

A new `golang` describe block covers both directions, so the fix cannot regress into over-rejecting:

| Case | Expected |
| --- | --- |
| `v1.0.invalid` | throws, with the "must be followed by a valid semver version" message |
| `v1.0.0` | accepted |
| `v0.0.0-20210922020428-25de7278fc84` (pseudo-version) | accepted |
| version with no `v` prefix | accepted |

</details>
