### PR TITLE
fix: preserve url encoding of + in version

### DIFF
--- a/src/encode.js
+++ b/src/encode.js
@@ -59,7 +59,7 @@ function encodeSubpath(subpath) {
 
 function encodeVersion(version) {
     return isNonEmptyString(version)
-        ? encodeURIComponent(version).replace(/%3A/g, ':').replace(/%2B/g, '+')
+        ? encodeURIComponent(version).replace(/%3A/g, ':')
         : ''
 }
 

--- a/test/data/contrib-tests.json
+++ b/test/data/contrib-tests.json
@@ -2,7 +2,7 @@
   {
     "description": "debian can have debian versions as part of version with plus sign",
     "purl": "pkg:deb/debian/libssl1.1@1.1.1n-0+deb10u3?arch=amd64&distro=debian-10",
-    "canonical_purl": "pkg:deb/debian/libssl1.1@1.1.1n-0+deb10u3?arch=amd64&distro=debian-10",
+    "canonical_purl": "pkg:deb/debian/libssl1.1@1.1.1n-0%2Bdeb10u3?arch=amd64&distro=debian-10",
     "type": "deb",
     "namespace": "debian",
     "name": "libssl1.1",


### PR DESCRIPTION
Based on update to the purl spec here: https://github.com/package-url/purl-spec/issues/58#issuecomment-3009152400