### PR TITLE
Return false instead of throwing in validate() for a bad npm namespace

### DIFF
--- a/src/purl-type.js
+++ b/src/purl-type.js
@@ -305,9 +305,12 @@ module.exports = {
                             return false
                         }
                         if (code0 !== 64 /*'@'*/) {
-                            throw new PurlError(
-                                `npm "namespace" component must start with an "@" character`
-                            )
+                            if (throws) {
+                                throw new PurlError(
+                                    `npm "namespace" component must start with an "@" character`
+                                )
+                            }
+                            return false
                         }
                         const namespaceWithoutAtSign = namespace.slice(1)
                         if (

--- a/test/package-url.spec.js
+++ b/test/package-url.spec.js
@@ -31,7 +31,7 @@ const TEST_FILE = [
     ...require('./data/contrib-tests.json')
 ]
 
-const { PackageURL } = require('../src/package-url')
+const { PackageURL, PurlType } = require('../src/package-url')
 
 function getNpmId(purl) {
     const { name, namespace } = purl
@@ -543,6 +543,26 @@ describe('PackageURL', function () {
                 purlWithUnderscore.toString(),
                 'pkg:pypi/typing-extensions-blah@1.0.0'
             )
+        })
+    })
+
+    describe('npm validate', function () {
+        it('should return false rather than throw for a bad namespace when throws is false', function () {
+            const purl = { type: 'npm', namespace: 'foo', name: 'bar' }
+            assert.strictEqual(PurlType.npm.validate(purl, false), false)
+        })
+
+        it('should still throw for a bad namespace when throws is true', function () {
+            const purl = { type: 'npm', namespace: 'foo', name: 'bar' }
+            assert.throws(
+                () => PurlType.npm.validate(purl, true),
+                /npm "namespace" component must start with an "@" character/
+            )
+        })
+
+        it('should accept a scoped namespace when throws is false', function () {
+            const purl = { type: 'npm', namespace: '@scope', name: 'bar' }
+            assert.strictEqual(PurlType.npm.validate(purl, false), true)
         })
     })
 })


### PR DESCRIPTION
The validators in `src/purl-type.js` share the `(purl, throws) => boolean` contract: on a violation they throw only when `throws` is true, and otherwise return false. Of the sixteen throw sites in the file, fifteen wrap the throw in `if (throws)`. The npm namespace check that requires a leading `@` was the odd one out and threw unconditionally.

Because of that, `PurlType.npm.validate(purl, false)` throws a `PurlError` for an npm purl whose namespace does not start with `@`, when the non-throwing path is supposed to return false. The constructor always calls with `throws=true`, so this only shows up when calling the boolean validator directly.

The fix wraps that one throw in the same `if (throws)` guard the sibling checks use and returns false when `throws` is false. Same shape as the golang parameter fix in #88, just a different site.

I added a few tests: a bad namespace with `throws=false` now returns false, a bad namespace with `throws=true` still throws, and a scoped namespace with `throws=false` returns true. Ran the full suite with mocha and it passes; the new false-return test fails on master before the change.

Signed-off-by per DCO.