### PR TITLE
fix: preserve case in npm names and scopes

### DIFF
--- a/src/purl-type.js
+++ b/src/purl-type.js
@@ -133,16 +133,6 @@ module.exports = {
                     }
                     return purl
                 },
-                // https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#npm
-                npm(purl) {
-                    lowerNamespace(purl)
-                    // Ignore lowercasing legacy names because they could be mixed case.
-                    // https://github.com/npm/validate-npm-package-name/tree/v6.0.0?tab=readme-ov-file#legacy-names
-                    if (!isNpmLegacyName(getNpmId(purl))) {
-                        lowerName(purl)
-                    }
-                    return purl
-                },
                 // https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#luarocks
                 luarocks(purl) {
                     lowerVersion(purl)
@@ -334,6 +324,9 @@ module.exports = {
                         }
                         return false
                     }
+                    // npm names and scopes are case-sensitive, including names
+                    // outside the public registry's known legacy packages.
+                    // https://packageurl.org/types/npm-definition.json
                     // The remaining checks are only for modern names.
                     // https://github.com/npm/validate-npm-package-name/tree/v6.0.0?tab=readme-ov-file#naming-rules
                     if (!isNpmLegacyName(id)) {
@@ -341,14 +334,6 @@ module.exports = {
                             if (throws) {
                                 throw new PurlError(
                                     `npm "namespace" and "name" components can not collectively be more than 214 characters`
-                                )
-                            }
-                            return false
-                        }
-                        if (loweredId !== id) {
-                            if (throws) {
-                                throw new PurlError(
-                                    `npm "name" component can not contain capital letters`
                                 )
                             }
                             return false

--- a/test/package-url.spec.js
+++ b/test/package-url.spec.js
@@ -479,6 +479,58 @@ describe('PackageURL', function () {
     })
 
     describe('npm', function () {
+        for (const [namespace, name] of [
+            [undefined, 'ExamplePackage'],
+            ['@examplescope', 'ExamplePackage'],
+            ['@ExampleScope', 'examplepackage'],
+            ['@ExampleScope', 'ExamplePackage'],
+            [undefined, 'examplepackage']
+        ]) {
+            const id = `${namespace ? `${namespace}/` : ''}${name}`
+            const purlString = `pkg:npm/${id.replace('@', '%40')}@1.0.0`
+
+            it(`should preserve case when constructing ${id}`, function () {
+                const purl = new PackageURL('npm', namespace, name, '1.0.0')
+                assert.strictEqual(purl.namespace, namespace)
+                assert.strictEqual(purl.name, name)
+                assert.strictEqual(purl.toString(), purlString)
+            })
+
+            it(`should preserve case when parsing ${id}`, function () {
+                const purl = PackageURL.fromString(purlString)
+                assert.strictEqual(purl.namespace, namespace)
+                assert.strictEqual(purl.name, name)
+                assert.strictEqual(purl.toString(), purlString)
+            })
+
+            it(`should validate ${id} without changing case`, function () {
+                const purl = { type: 'npm', namespace, name }
+                assert.strictEqual(
+                    PackageURL.Type.npm.validate(purl, false),
+                    true
+                )
+                assert.strictEqual(
+                    PackageURL.Type.npm.validate(purl, true),
+                    true
+                )
+                assert.strictEqual(purl.namespace, namespace)
+                assert.strictEqual(purl.name, name)
+            })
+        }
+
+        it('should keep differently capitalized package identities distinct', function () {
+            for (const [first, second] of [
+                ['pkg:npm/ExamplePackage', 'pkg:npm/examplepackage'],
+                ['pkg:npm/%40ExampleScope/pkg', 'pkg:npm/%40examplescope/pkg'],
+                ['pkg:npm/MEAN', 'pkg:npm/mean']
+            ]) {
+                assert.notStrictEqual(
+                    PackageURL.fromString(first).toString(),
+                    PackageURL.fromString(second).toString()
+                )
+            }
+        })
+
         it("should allow legacy names to be mixed case, match a builtin, or contain ~'!()* characters", function () {
             for (const legacyName of npmLegacyNames) {
                 let purl


### PR DESCRIPTION
# Preserve case in npm package names and scopes

Constructing or parsing an npm PURL currently lowercases scopes and names that are not in the bundled legacy-name list. For example, `pkg:npm/%40ExampleScope/ExamplePackage@1.0.0` becomes `pkg:npm/%40examplescope/examplepackage@1.0.0`, changing the package identity.

Use the default identity normalizer for npm and remove the uppercase rejection from its validator. The current [npm type definition](https://github.com/package-url/purl-spec/blob/main/types/npm-definition.json) marks both namespace and name as case-sensitive. Existing legacy-name exceptions and other validation rules remain in place.

Add coverage for construction, parsing/serialization and direct validation of mixed-case names and scopes, plus lowercase controls and distinct identities. This also covers names outside the bundled legacy list, as needed for private registries.

Validation on Node.js v24.15.0:
- Baseline suite: 187 passing.
- New regression tests before the fix: 13 failing, 11 passing in the npm subset.
- Full suite after the fix: 203 passing.
- Original standalone reproduction, targeted invalid-name checks, Prettier and `git diff --check`: passed.

Fixes #95.
